### PR TITLE
Remove additional dependencies

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -40,37 +40,7 @@
     </dependency>
     <dependency>
         <groupId>com.google.oauth-client</groupId>
-        <artifactId>google-oauth-client-jetty</artifactId>
-        <version>1.12.0-beta</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.api-client</groupId>
-        <artifactId>google-api-client-servlet</artifactId>
-        <version>1.30.4</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.api-client</groupId>
-        <artifactId>google-api-client-extensions</artifactId>
-        <version>1.6.0-beta</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-oauth2</artifactId>
-      <version>v2-rev131-1.23.0</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.oauth-client</groupId>
-        <artifactId>google-oauth-client</artifactId>
-        <version>1.30.4</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client-appengine</artifactId>
-        <version>1.30.4</version>
-    </dependency>
-    <dependency>
-        <groupId>com.google.oauth-client</groupId>
-        <artifactId>google-oauth-client-servlet</artifactId>
         <version>1.30.4</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This may be the reason the web-page causes errors and doesn't display the sign-in window. This still runs perfectly fine without them, leading me to believe they were left over from previous testing I've done, apparently having dependencies that rely on differing versions but use the same methods/code causes conflicts.