### PR TITLE
Fix eventlisting redirect after oAuth

### DIFF
--- a/capstone/src/main/java/com/google/sps/servlets/Auth.java
+++ b/capstone/src/main/java/com/google/sps/servlets/Auth.java
@@ -15,7 +15,7 @@ public class Auth extends AbstractAppEngineAuthorizationCodeServlet {
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
-    response.sendRedirect("/eventlisting");
+    response.sendRedirect("/eventlisting.html");
   }
 
   @Override

--- a/capstone/src/main/java/com/google/sps/servlets/EventListing.java
+++ b/capstone/src/main/java/com/google/sps/servlets/EventListing.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 public class EventListing extends HttpServlet {
 
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Calendar service = Utils.loadCalendarClient();
     Event event =
         new Event()

--- a/capstone/src/main/webapp/eventlisting.html
+++ b/capstone/src/main/webapp/eventlisting.html
@@ -14,7 +14,9 @@
       <p>Information About the Event</p>
       <div class="bottom"></div> <! end bottom -->
       <div class="middle">
-        <button onclick="login()">Add to Calendar</button>
+        <form action = "/eventlisting" method = "POST">
+          <button type="button" onclick="login()">Add to Calendar</button>
+        </form>
       </div>
     </div> <!-- end holder div -->
   </body>


### PR DESCRIPTION
By adding a form to the button, when the user clicks it runs oAuth and then should redirect to eventlisting into the doPost to add the events, this reduces the need for possibly two buttons.